### PR TITLE
[202406.xx] fix sockets not being freed properly when an unplanned disconnection happens

### DIFF
--- a/libraries/common/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/common/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -559,11 +559,13 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
 
         if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {
-            LogError( ( "Failed to close connection: SOCKETS_Shutdown call failed. %d", transportSocketStatus ) );
-            shutdownStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
+            LogError( ( "Failed to close connection, it may already be disconnected: SOCKETS_Shutdown call failed. %d", transportSocketStatus ) );
+            /* Here, a disconnection by the physical layer likely occured. lwip_shutdown() -> done_socket() in lwip has already cleaned its structs in this object */
+            shutdownStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
         }
         else
         {
+            /* Here, the user manually initiates disconnect on a live connection, object is freed as usual */
             shutdownStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
         }
 


### PR DESCRIPTION
When an unplanned disconnection happens, the socket will first be shutdown, then closed. However, in the lwip stack a disconnected socket will have its lwip_sock *sock->conn field as NULL, this will cause lwip_shutdown to return internal error and skip SOCKETS_Close As a result, the remainder socket structures are also not freed and sockets_allocated is never released

This commit marks the unplanned disconnection case as valid, allowing SOCKETS_Close to be run and release the socket object completely. In the case of unplanned disconnection, the lwip stack has already taken care of the lwip-related structs with done_socket(), so there should not be any memory leaks