### PR TITLE
[202406.xx-mbed363] bug fix for tls connection

### DIFF
--- a/libraries/common/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/common/freertos_plus/standard/tls/src/iot_tls.c
@@ -314,6 +314,7 @@ static int prvCheckCertificate( void * pvContext,
  * @param[in] pucHash Length in bytes of hash to be signed.
  * @param[in] uiHashLen Byte array of hash to be signed.
  * @param[out] pucSig RSA signature bytes.
+ * @param[in] pxSigSize  Size in bytes of signature buffer (for mbedtls-3.x.x and above)
  * @param[in] pxSigLen Length in bytes of signature buffer.
  * @param[in] piRng Unused.
  * @param[in] pvRng Unused.
@@ -325,6 +326,9 @@ static int prvPrivateKeySigningCallback( void * pvContext,
                                          const unsigned char * pucHash,
                                          size_t xHashLen,
                                          unsigned char * pucSig,
+#if MBEDTLS_VERSION_MAJOR >= 3 && MBEDTLS_VERSION_MINOR >= 6
+                                         size_t * pxSigSize,
+#endif
                                          size_t * pxSigLen,
                                          int ( * piRng )( void *,
                                                           unsigned char *,
@@ -333,7 +337,8 @@ static int prvPrivateKeySigningCallback( void * pvContext,
 {
     CK_RV xResult = CKR_OK;
     int lFinalResult = 0;
-    TLSContext_t * pxTLSContext = ( TLSContext_t * ) pvContext;
+    mbedtls_pk_context * pxPKContext = (mbedtls_pk_context *) pvContext;
+    TLSContext_t * pxTLSContext = ( TLSContext_t * ) pxPKContext->pk_ctx;
     CK_MECHANISM xMech = { 0 };
     CK_BYTE xToBeSigned[ 256 ];
     CK_ULONG xToBeSignedLen = sizeof( xToBeSigned );


### PR DESCRIPTION
Purpose:
* bug fix for tls connection

Note:
* When KEY_PLAINTEXT is set 0, prvInitializeClientCredential() will be called, and prvPrivateKeySigningCallback will be registered.
* During certificate verification, the callback will be called upon, and there are two issues in the callback. (1) The number of argument does not match, causing argument misalignment (missing signature size for mbedtls-3.6.3) (2) The pvContext given was PK context, but in the callback it requires TLS context.
* Solution: Corrected the number of argument if using mbedtls-3.6.3, and ensuring the TLS context is obtained.