### PR TITLE
[202406.xx-mbed363][common] Allow access to private members of MbedTLS struct members

### DIFF
--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -58,6 +58,7 @@
 #include "core_pki_utils.h"
 
 /* mbedTLS includes. */
+#include "mbedtls/library/common.h"
 #include "mbedtls/pk.h"
 #include "mbedtls/oid.h"
 

--- a/libraries/common/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/common/freertos_plus/standard/tls/src/iot_tls.c
@@ -36,6 +36,7 @@
 #include "core_pki_utils.h"
 
 /* mbedTLS includes. */
+#include "mbedtls/library/common.h"
 #include "mbedtls/platform.h"
 #if MBEDTLS_VERSION_MAJOR >= 3 && MBEDTLS_VERSION_MINOR >= 6
 #if defined(CONFIG_AMEBAZ2) || defined(CONFIG_AMEBAD)


### PR DESCRIPTION
* Included "mbedtls/library/common.h" to allow the access to private members of MbedTLS structs